### PR TITLE
Upgrade runtime to Elixir 1.5.1 and Erlang 20

### DIFF
--- a/roles/dotcom/files/docker/runtime/Dockerfile
+++ b/roles/dotcom/files/docker/runtime/Dockerfile
@@ -1,7 +1,7 @@
-FROM erlang:19.2.3
+FROM erlang:20.0
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.4.2" \
+ENV ELIXIR_VERSION="v1.5.1" \
     LANG=C.UTF-8
 
 RUN set -xe \


### PR DESCRIPTION
@gerhard I'm finishing up a big Phoenix 1.3 upgrade and would also like to bump to Elixir 1.5.1 and Erlang 20. I'm still not quite sure how to do this, but I _believe_ we bump the versions in the Dockerfile, push a new runtime to Docker Hub, and redeploy. 

1. Is that correct?
2. There is also a hardcoded SHA in that file which I assume needs to change, but I'm not sure where you got this from...
3. Can we document this (and where) so I can do it again in the future?

Please let me know. Thanks!