### PR TITLE
Enable HTTP/2 and allow HSTS preloading

### DIFF
--- a/roles/concourse/templates/nginx.concourse.j2
+++ b/roles/concourse/templates/nginx.concourse.j2
@@ -7,7 +7,7 @@ server {
 }
 
 server {
-  listen 443 ssl;
+  listen 443 ssl http2;
   server_name {{ fqdn }};
 
   # All user agents will use https://, remember for 1 year

--- a/roles/concourse/templates/nginx.concourse.j2
+++ b/roles/concourse/templates/nginx.concourse.j2
@@ -10,9 +10,6 @@ server {
   listen 443 ssl http2;
   server_name {{ fqdn }};
 
-  # All user agents will use https://, remember for 1 year
-  # Add this domain to the user agent's HSTS preload list
-  add_header Strict-Transport-Security 'max-age=31536000; preload';
   # The page can only be displayed in a frame on the same origin as the page itself
   add_header X-Frame-Options SAMEORIGIN;
 

--- a/roles/dotcom/templates/changelog.com.j2
+++ b/roles/dotcom/templates/changelog.com.j2
@@ -6,7 +6,7 @@ server {
 }
 
 server {
-  listen 443 ssl;
+  listen 443 ssl http2;
   include /etc/nginx/sites/{{ fqdn }}.common;
 
   # All user agents will use https://, remember for 1 year

--- a/roles/dotcom/templates/changelog.com.j2
+++ b/roles/dotcom/templates/changelog.com.j2
@@ -10,8 +10,8 @@ server {
   include /etc/nginx/sites/{{ fqdn }}.common;
 
   # All user agents will use https://, remember for 1 year
-  # Add this domain to the user agent's HSTS preload list
-  add_header Strict-Transport-Security 'max-age=31536000; preload';
+  # Allow adding the domain to the HSTS Preload List
+  add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
 
   ssl on;
   ssl_certificate /etc/nginx/ssl/star.changelog.com.crt;

--- a/roles/netdata/templates/nginx.netdata.j2
+++ b/roles/netdata/templates/nginx.netdata.j2
@@ -12,7 +12,7 @@ upstream netdata {
 }
 
 server {
-  listen 443 ssl;
+  listen 443 ssl http2;
   server_name {{ fqdn }};
 
   ssl on;


### PR DESCRIPTION
Before merging this PR, HTTPS on `nightly.changelog.com` must be fixed, since HSTS preloading `changelog.com` will force the whole domain to HTTPS, thus breaking that subdomain. Not sure if there are any other such problematic subdomains.

**EDIT:**  
Apparently `email.changelog.com` too. Seems like that might be a problem. Maybe putting that behind Fastly would help?